### PR TITLE
Make test compatible with testing-library v4.0

### DIFF
--- a/tests/unit/application/controllers/admin/bestitAmazonPay4OxidInitTest.php
+++ b/tests/unit/application/controllers/admin/bestitAmazonPay4OxidInitTest.php
@@ -337,6 +337,11 @@ class bestitAmazonPay4OxidInitTest extends bestitAmazon4OxidUnitTestCase
         $oBestitAmazonPay4OxidInit::onActivate();
         $oBestitAmazonPay4OxidInit::onActivate();
         $oBestitAmazonPay4OxidInit::onActivate();
+
+        $this->assertLoggedException(
+            OxidEsales\Eshop\Core\Exception\StandardException::class,
+            'exceptionError'
+        );
     }
 
     /**


### PR DESCRIPTION
There was a breaking change in oxid-esales/testing-library v4.0.
After each test run the exception log file is scanned for entries and if there are some unexpected entries, the tests fails.
\bestitAmazonPay4OxidInitTest::testOnActivate willingly creates en entry in the exception log file, so it has to be asserted with
\OxidEsales\TestingLibrary\BaseTestCase::assertLoggedException