### PR TITLE
first bestit module update crashes the shop

### DIFF
--- a/application/controllers/admin/bestitamazonpay4oxid_init.php
+++ b/application/controllers/admin/bestitamazonpay4oxid_init.php
@@ -348,8 +348,8 @@ class bestitAmazonPay4Oxid_init
         $aVersions = (array)self::_getConfig()->getConfigParam('aModuleVersions');
 
         $aPossibleModuleNames = array(
-            'jagAmazonPayment4Oxid',
-            'bestitAmazonPay4Oxid'
+            'bestitAmazonPay4Oxid',
+            'jagAmazonPayment4Oxid'
         );
 
         foreach ($aPossibleModuleNames as $sPossibleModuleName) {


### PR DESCRIPTION
puh, ich versuche das möglichst ohne Ausschweifungen darzulegen.
Ausgangssituation ist folgende: 4.10.7 CE, altes jag-Modul v2.2.2 wurde entfernt und bestit Modul installiert.
In der oxconfig Tabelle in aModuleVersions war der Versionseintrag dafür noch vorhanden.
Bei der Erstinstallation des bestit Moduls (bzw im oxActivate Event) sucht das neue Modul nach dem alten, findet nichts und wird erfolgreich installiert. Am Ende der Installation soll die aktuelle Version des Moduls in die Tabelle oxconfig unter "sUpdateFrom" gespeichert werden, dazu wird an der geänderten Stelle eben "aModuleVersions" nach Modulversionen durchsucht und weil zuerst das alte Modul gesucht wird, wird die Version 2.2.2 des alten jag-Moduls gespeichert.

Beim Modul-Update holt sich das Modul die Version aus sUpdateFrom, findet aber die alte Version vom jag Modul und glaub, die DB updaten und das alte Modul deaktivieren zu müssen, obwohl eigentlich das neure Modul mit allen DB Anpassungen installiert ist. Genau an dieser Stelle kracht es, weil das alte Modul überhaupt nicht mehr vorhanden ist, folglich kann es nicht geladen und deaktiviert werden.
Folglich bricht die Installation mit der Fehlermeldung "Module kann nicht geladen werden" ab und es werden Klassen-Erweiterungen deaktiviert, aber kein Cache geleert, wodurch der Aufruf oxViewConfig->isAmaPayActive (oder sowas) in den TPL Blocks fehl schlägt = Shop kaputt.

Hier müsste man anders prüfen, ob das Modul aktualisiert werden müsste. Bzw eigentlich könnte man "jagAmazonPayment4Oxid" auch völlig weglassen, denn es wurde ja gerade das neue bestit Modul installiert.