### PR TITLE
Wrong capture title causes js errors

### DIFF
--- a/application/views/bestitamazonpay4oxid_paybutton.tpl
+++ b/application/views/bestitamazonpay4oxid_paybutton.tpl
@@ -25,7 +25,7 @@
                 }).bind('payWithAmazonButton[{$sButtonId}]');
             });
         [{/capture}]
-        [{oxscript add=$smarty.capture.sBestitAmazonLoginScript}]
+        [{oxscript add=$smarty.capture.sBestitAmazonScript}]
         <div class="amazonContentGroup">
             [{if $showOrText}]
                 <span class="amazonPayPreOr">[{oxmultilang ident="BESTITAMAZONPAY_PAY_OR"}]</span>


### PR DESCRIPTION
Problem desctiprion: The name of the capture in Line 6 is "sBestitAmazonScript", but in line 28 oxscript wants to output "sBestitAmazonLoginScript", which is empty, this causes oxscript to output collected scripts right away in the middle of the page, and that causes js-errors on the page.