### PR TITLE
fix payment check if jagamazon was installed

### DIFF
--- a/application/controllers/admin/bestitamazonpay4oxid_init.php
+++ b/application/controllers/admin/bestitamazonpay4oxid_init.php
@@ -226,7 +226,7 @@ class bestitAmazonPay4Oxid_init
     {
         $sSql = "SELECT COUNT(OXID)
             FROM oxpayments
-            WHERE OXID IN ('jagamazon', 'bestitamazon')";
+            WHERE oxid = 'bestitamazon'";
 
         //Insert payment records to DB
         $iRes = self::_getDatabase()->getOne($sSql);


### PR DESCRIPTION
bestitAmazonPay4Oxid_init::onActivate() only executes install.sql when "bestitamazon" or "jagamazon" does not exist
bestitAmazonPay4Oxid::isActive() checks only if paymentid "bestitamazon" is available

so if you have an shop upgrade with old jag amazon module installed, payment button is not shown in bestit amazon module.