### PR TITLE
Make sure that the OXID stack is available for the metadata file

### DIFF
--- a/metadata.php
+++ b/metadata.php
@@ -8,9 +8,13 @@
 
 $sMetadataVersion = '1.1';
 
-require_once dirname(__FILE__).'/application/controllers/admin/bestitamazonpay4oxid_init.php';
-$sCurrentVersion = (isset($blPreventVersionCheck) && $blPreventVersionCheck === true) ?
-    null : bestitAmazonPay4Oxid_init::getCurrentVersion();
+$blStackAvailable = function_exists('oxNew');
+
+if ($blStackAvailable) {
+    include_once dirname(__FILE__) . '/application/controllers/admin/bestitamazonpay4oxid_init.php';
+    $sCurrentVersion = (isset($blPreventVersionCheck) && $blPreventVersionCheck === true) ?
+        null : bestitAmazonPay4Oxid_init::getCurrentVersion();
+}
 
 /**
  * Module information
@@ -366,10 +370,12 @@ $aModule = array(
     )
 );
 
-if (bestitAmazonPay4Oxid_init::isOxidSix() === false) {
-    $aModule['extend']['oxorder'] = 'bestit/amazonpay4oxid/ext/bestitamazonpay4oxid_oxorder_oxid5';
-}
+if ($blStackAvailable) {
+    if (bestitAmazonPay4Oxid_init::isOxidSix() === false) {
+        $aModule['extend']['oxorder'] = 'bestit/amazonpay4oxid/ext/bestitamazonpay4oxid_oxorder_oxid5';
+    }
 
-if ($sCurrentVersion !== null && version_compare($sCurrentVersion, $aModule['version'], '<')) {
-    bestitAmazonPay4Oxid_init::flagForUpdate();
+    if ($sCurrentVersion !== null && version_compare($sCurrentVersion, $aModule['version'], '<')) {
+        bestitAmazonPay4Oxid_init::flagForUpdate();
+    }
 }

--- a/tests/acceptance/FrontendTest.php
+++ b/tests/acceptance/FrontendTest.php
@@ -25,6 +25,33 @@ class FrontendTest extends oxAcceptanceTestCase
     }
 
     /**
+     * Reset columns if the exits.
+     *
+     * @param int $shopId
+     */
+    public function activateModules($shopId = 1)
+    {
+        if (method_exists($this, 'executeSql')) {
+            $aTableColumns = array(
+                'BESTITAMAZONORDERREFERENCEID' => 'oxorder',
+                'BESTITAMAZONAUTHORIZATIONID' => 'oxorder',
+                'BESTITAMAZONCAPTUREID' => 'oxorder',
+                'BESTITAMAZONID' => 'oxuser',
+            );
+
+            foreach ($aTableColumns as $sColumn => $sTable) {
+                try {
+                    $this->executeSql("ALTER TABLE `{$sTable}` DROP `{$sColumn}`");
+                } catch (Throwable $oException) {
+                    // Do nothing
+                }
+            }
+        }
+
+        parent::activateModules($shopId);
+    }
+
+    /**
      * Returns configuration data for tests
      *
      * @return array


### PR DESCRIPTION
Ensures that the OXID stack is available before we run additional actions on the metadata file. If the stack is not available and the file gets processed all entries are set up for OXID 6.2 and we are also fine.