### PR TITLE
OXAP-149 Added street parsing without the config of a country iso code

### DIFF
--- a/application/views/admin/de/bestitamazonpay4oxid_lang.php
+++ b/application/views/admin/de/bestitamazonpay4oxid_lang.php
@@ -76,7 +76,6 @@ $aLang = array(
     'SHOP_MODULE_blShowAmazonPayButtonAtDetails'                                     => 'Amazon Pay-Button auf Produktdetailseite anzeigen',
     'SHOP_MODULE_blShowAmazonPayButtonAtCartPopup'                                   => 'Amazon Pay-Button im Warenkorb Popup anzeigen',
     'SHOP_MODULE_aAmazonReverseOrderCountries'                                       => 'ISO2 Code der Länder, bei denen die AddressLineX Rückgaben von Amazon vertauscht sind (AddressLine1 == Firma, AddressLine2 == Straße)',
-    'SHOP_MODULE_aAmazonStreetNoStreetCountries'                                     => 'ISO2 Code der Länder, die Straße und Hausnummer vertauscht haben',
 
     'SHOP_MODULE_GROUP_bestitAmazonPay4OxidLanguages'  => 'Sprach Einstellungen',
     'SHOP_MODULE_aAmazonLanguages'                      => "Sprach Einstellungen ('Oxid Sprachk&uuml;rzel' => 'Amazon Sprachwert')",

--- a/application/views/admin/en/bestitamazonpay4oxid_lang.php
+++ b/application/views/admin/en/bestitamazonpay4oxid_lang.php
@@ -76,7 +76,6 @@ $aLang = array(
     'SHOP_MODULE_blShowAmazonPayButtonAtDetails'                                     => 'Show Amazon Pay button on the details page',
     'SHOP_MODULE_blShowAmazonPayButtonAtCartPopup'                                   => 'Show Amazon Pay button on the cart popup',
     'SHOP_MODULE_aAmazonReverseOrderCountries'                                       => 'ISO2 code of the countries where the AddressLineX returned from Amazon are reversed (AddressLine1 == company, AddressLine2 == street)',
-    'SHOP_MODULE_aAmazonStreetNoStreetCountries'                                     => 'ISO2 Code of the countries that have reversed street and house numbers',
 
     'SHOP_MODULE_GROUP_bestitAmazonPay4OxidLanguages'  => 'Language Settings',
     'SHOP_MODULE_aAmazonLanguages'                      => "Language mapping ('Oxid language abbreviation' => 'Amazon language value')",

--- a/metadata.php
+++ b/metadata.php
@@ -352,13 +352,6 @@ $aModule = array(
             'value' => array('DE', 'AT', 'FR'),
             'position' => 11
         ),
-        array(
-            'group' => 'bestitAmazonPay4OxidConfiguration',
-            'name' => 'aAmazonStreetNoStreetCountries',
-            'type' => 'arr',
-            'value' => array('FR', 'GB'),
-            'position' => 12
-        ),
     ),
     'events' => array(
         'onActivate' => 'bestitAmazonPay4Oxid_init::onActivate',

--- a/tests/unit/application/models/bestitAmazonPay4OxidAdressUtilTest.php
+++ b/tests/unit/application/models/bestitAmazonPay4OxidAdressUtilTest.php
@@ -2,7 +2,7 @@
 
 use Psr\Log\NullLogger;
 
-require_once dirname(__FILE__).'/../../bestitAmazon4OxidUnitTestCase.php';
+require_once dirname(__FILE__) . '/../../bestitAmazon4OxidUnitTestCase.php';
 
 /**
  * Unit test for class bestitAmazonPay4OxidAddressUtil
@@ -12,6 +12,15 @@ require_once dirname(__FILE__).'/../../bestitAmazon4OxidUnitTestCase.php';
  */
 class bestitAmazonPay4OxidAddressUtilTest extends bestitAmazon4OxidUnitTestCase
 {
+    /**
+     * Started object to test.
+     *
+     * Filled by the setup method.
+     *
+     * @var bestitAmazonPay4OxidAddressUtil|null
+     */
+    private $fixture;
+
     /**
      * @param oxConfig          $oConfig
      * @param DatabaseInterface $oDatabase
@@ -32,13 +41,97 @@ class bestitAmazonPay4OxidAddressUtilTest extends bestitAmazon4OxidUnitTestCase
     }
 
     /**
-     * @group unit
+     * Returns assert to check if the single address line gets parsed correctly.
+     *
+     * @return array
      */
-    public function testCreateInstance()
+    public function getParseSingleAddressAsserts()
+    {
+        return array(
+            // test desc => Test value, country, result array.
+            'Test german address' => array('Teststraße 1', 'DE', array('Name' => 'Teststraße', 'Number' => '1')),
+            'Test german address, no whitespace' => array(
+                'Teststreet1a',
+                'DE',
+                array('Name' => 'Teststreet', 'Number' => '1a')
+            ),
+            'Test german address with add info' => array(
+                'Teststreet 1a addinfo',
+                'DE',
+                array('Name' => 'Teststreet', 'Number' => '1a', 'AddInfo' => 'addinfo')
+            ),
+            'Test german separated address with add info' => array(
+                'Test street 1a addinfo',
+                'DE',
+                array('Name' => 'Test street', 'Number' => '1a', 'AddInfo' => 'addinfo')
+            ),
+            'Test german address with add info no whitespace' => array(
+                'Teststreet1 addinfo',
+                'DE',
+                array('Name' => 'Teststreet', 'Number' => '1', 'AddInfo' => 'addinfo')
+            ),
+            'Test address format "street streetnumber" without streetnumber' => array(
+                'Teststreet',
+                'DE',
+                array('Name' => 'Teststreet')
+            ),
+            'Test FR address without streetnumber' => array(
+                'Teststreet',
+                'FR',
+                array('Name' => 'Teststreet', 'Number' => '')
+            ),
+            'Test FR address' => array(
+                '1a Teststreet',
+                'FR',
+                array('Name' => 'Teststreet', 'Number' => '1a')
+            ),
+            'Test FR address no whitespace' => array(
+                '1Teststreet',
+                'FR',
+                array('Name' => 't', 'Number' => '1Teststree')
+            ),
+            'Test FR address no whitespace with add info' => array(
+                '1Teststreet addInfo',
+                'FR',
+                array('Number' => '1Teststreet', 'Name' => 'addInfo')
+            )
+        );
+    }
+
+    /**
+     * Sets up the test.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->fixture = new bestitAmazonPay4OxidAddressUtil();
+
+        $this->fixture->setLogger(new NullLogger());
+    }
+
+    /**
+     * @group unit
+     *
+     * @return void
+     */
+    public function testInheritanceOfObject()
     {
         $oBestitAmazonPay4OxidAddressUtil = new bestitAmazonPay4OxidAddressUtil();
-        $oBestitAmazonPay4OxidAddressUtil->setLogger(new NullLogger());
-        self::assertInstanceOf('bestitAmazonPay4OxidAddressUtil', $oBestitAmazonPay4OxidAddressUtil);
+
+        self::assertInstanceOf('bestitAmazonPay4OxidContainer', $this->fixture);
+    }
+
+    /**
+     * Checks if the required interface is registered.
+     *
+     * @return void
+     */
+    public function testInterfacesOfObject()
+    {
+        self::assertInstanceOf('\Psr\Log\LoggerAwareInterface', $this->fixture);
     }
 
     /**
@@ -57,16 +150,11 @@ class bestitAmazonPay4OxidAddressUtilTest extends bestitAmazon4OxidUnitTestCase
 
         $oConfig->expects($this->any())
             ->method('getConfigParam')
-            ->with($this->logicalOr(
-                $this->equalTo('aAmazonReverseOrderCountries'),
-                $this->equalTo('aAmazonStreetNoStreetCountries')
-            ))
+            ->with($this->equalTo('aAmazonReverseOrderCountries'))
             ->will($this->returnCallback(
                 function($sParameter) {
                     if ($sParameter === 'aAmazonReverseOrderCountries') {
                         return array('DE', 'AT', 'FR');
-                    } elseif ($sParameter === 'aAmazonStreetNoStreetCountries') {
-                        return array('FR');
                     }
                 }
             ));
@@ -194,96 +282,36 @@ class bestitAmazonPay4OxidAddressUtilTest extends bestitAmazon4OxidUnitTestCase
     }
 
     /**
+     * Tests if the given address lines are parsed correctly.
+     *
      * @covers ::_parseSingleAddress()
+     * @dataProvider getParseSingleAddressAsserts
      * @throws ReflectionException
+     *
+     * @param string $addressLine
+     * @param string $countryIso
+     * @param array $checkedValues The result array of the parsing.
+     *
+     * @return void
      */
-    public function test_parseSingleAddress()
+    public function test_parseSingleAddress($addressLine, $countryIso, array $checkedValues)
     {
-        $oConfig = $this->_getConfigMock();
-        $oConfig->expects($this->any())
-            ->method('getConfigParam')
-            ->with('aAmazonStreetNoStreetCountries')
-            ->will($this->returnValue(array('FR')));
-
-        $oBestitAmazonPay4OxidAddressUtil = $this->_getObject(
-            $oConfig,
-            $this->_getDatabaseMock(),
-            $this->_getLanguageMock()
-        );
-
-        $oBestitAmazonPay4OxidAddressUtil->setLogger(new NullLogger());
-
-        // Test german address
-        $aTestResult = $this->callMethod(
-            $oBestitAmazonPay4OxidAddressUtil,
+        $testResult = $this->callMethod(
+            $this->fixture,
             '_parseSingleAddress',
-            array('Teststreet 1', 'DE')
+            array($addressLine, $countryIso)
         );
-        self::assertEquals(array(
-            'Name' => 'Teststreet',
-            'Number' => '1'
-        ), array(
-            'Name' => $aTestResult['Name'],
-            'Number' => $aTestResult['Number']
-        ));
 
-        // Test german address with add info
-        $aTestResult = $this->callMethod(
-            $oBestitAmazonPay4OxidAddressUtil,
-            '_parseSingleAddress',
-            array('Teststreet 1 addinfo', 'DE')
-        );
-        self::assertEquals(array(
-            'Name' => 'Teststreet',
-            'Number' => '1',
-            'AddInfo' => 'addinfo'
-        ), array(
-            'Name' => $aTestResult['Name'],
-            'Number' => $aTestResult['Number'],
-            'AddInfo' => $aTestResult['AddInfo']
-        ));
+        self::assertTrue(is_array($testResult));
 
-        // Test FR address
-        $aTestResult = $this->callMethod(
-            $oBestitAmazonPay4OxidAddressUtil,
-            '_parseSingleAddress',
-            array('1 Teststreet', 'FR')
-        );
-        self::assertEquals(array(
-            'Name' => 'Teststreet',
-            'Number' => '1'
-        ), array(
-            'Name' => $aTestResult['Name'],
-            'Number' => $aTestResult['Number']
-        ));
-
-        // Test FR address without streetnumber
-        $aTestResult = $this->callMethod(
-            $oBestitAmazonPay4OxidAddressUtil,
-            '_parseSingleAddress',
-            array('Teststreet', 'FR')
-        );
-        self::assertEquals(array(
-            'Name' => 'Teststreet',
-            'Number' => ''
-        ), array(
-            'Name' => $aTestResult['Name'],
-            'Number' => $aTestResult['Number']
-        ));
-
-        // Test address format "street streetnumber" without streetnumber
-        $aTestResult = $this->callMethod(
-            $oBestitAmazonPay4OxidAddressUtil,
-            '_parseSingleAddress',
-            array('Teststreet', 'DE')
-        );
-        self::assertEquals(array(
-            'Name' => 'Teststreet',
-            'Number' => ''
-        ), array(
-            'Name' => $aTestResult['Name'],
-            'Number' => $aTestResult['Number']
-        ));
+        foreach ($checkedValues as $field => $value) {
+            self::assertArrayHasKey($field, $testResult);
+            self::assertSame(
+                $value,
+                $testResult[$field],
+                sprintf('The value of field %s does not match.', $field)
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
- Fixed the wrong type hint for the parsing return
- Refactored the parsing unit test to a data provider and fixture
- Removed unused configuration
- Made the switches for the relevant address parsing more speaking

Signed-off-by: Bjoern Lange <bjoern.lange@bestit-online.de>