### PR TITLE
Add parent call

### DIFF
--- a/ext/bestitamazonpay4oxid_oxemail.php
+++ b/ext/bestitamazonpay4oxid_oxemail.php
@@ -26,6 +26,7 @@ class bestitAmazonPay4Oxid_oxEmail extends bestitAmazonPay4Oxid_oxEmail_parent
      */
     public function __construct()
     {
+        parent::__construct();
         $this->_oLogger = $this->_getContainer()->getLogger();
     }
 


### PR DESCRIPTION
This class extends OxidEsales\Eshop\Core\Email and therefor also has to call this class constructor.
Otherwise OXID eShop Enterprise Edition tests fail with this module enabled.