### PR TITLE
Add phpunit.xml

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,21 @@
+<phpunit backupGlobals="true"
+         backupStaticAttributes="false"
+         cacheTokens="true"
+         colors="false"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         printerClass="\OxidEsales\TestingLibrary\Printer"
+         forceCoversAnnotation="false"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false"
+         verbose="false">
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">../application</directory>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
Tests depend on OXID's testing_library anyway, so we can use the
\OxidEsales\TestingLibrary\Printer for printing test results. This
will help preventing session issues in tests with OXID 6.2 compilation and higher.

