### PR TITLE
OXAP-348 Link newsletter subscription from old account to new account

### DIFF
--- a/application/models/bestitamazonpay4oxidloginclient.php
+++ b/application/models/bestitamazonpay4oxidloginclient.php
@@ -176,6 +176,47 @@ class bestitAmazonPay4OxidLoginClient extends bestitAmazonPay4OxidContainer
     }
 
     /**
+     * Check if user with Email from Amazon exists
+     *
+     * @param  string $sId The id of the user
+     *
+     * @return array
+     * @throws oxConnectionException
+     */
+    public function oxidNewsletterSubscriptionExists($sId)
+    {
+        $sSql = "SELECT *
+            FROM oxnewssubscribed
+            WHERE OXUSERID = {$this->getDatabase()->quote($sId)}";
+
+        return $this->getDatabase()->getRow($sSql);
+    }
+
+    /**
+     * Delete OXID user by ID
+     *
+     * @param  string $sOldId The id of the old user
+     * @param  string $sNewId The id of the new user
+     *
+     * @return object
+     * @throws oxConnectionException
+     */
+    public function linkNewsletterToNewUser($sOldId, $sNewId)
+    {
+        $this->getLogger()->debug(
+            'Link newsletter subscription from old oxuser to new oxuser',
+            array('oldOxId' => $sOldId,
+                  'newOxId' => $sNewId)
+        );
+
+        $sSql = "UPDATE oxnewssubscribed
+            SET OXUSERID = {$this->getDatabase()->quote($sNewId)}
+            WHERE OXUSERID = {$this->getDatabase()->quote($sOldId)}";
+
+        return $this->getDatabase()->execute($sSql);
+    }
+
+    /**
      * Create new oxid user with details from Amazon
      *
      * @param stdClass $oUserData The oxid user data

--- a/ext/bestitamazonpay4oxid_oxcmp_user.php
+++ b/ext/bestitamazonpay4oxid_oxcmp_user.php
@@ -184,6 +184,12 @@ class bestitAmazonPay4Oxid_oxcmp_user extends bestitAmazonPay4Oxid_oxcmp_user_pa
                 array('oxId' => $sUserId)
             );
 
+            // Check if a newsletter subscription existed on the old account
+            $aNewsletterData = $oLoginClient->oxidNewsletterSubscriptionExists($aUserData['OXID']);
+            if ($aNewsletterData['OXID']) {
+                $oLoginClient->linkNewsletterToNewUser($aUserData['OXID'], $sUserId);
+            }
+
             $oSession->setVariable('usr', $sUserId);
             $oUtils->redirect($sRedirectUrl, false);
             return;


### PR DESCRIPTION
* The Amazon Pay modul Logic looks if the amazon user id exists or an email from the user in the database. If just a guest account exists it gets deleted and a new  account is created.
* This fixes the linking of newsletter subscription that might exists.