### PR TITLE
Update Tag Version from 3.6.8 to 3.6.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "oxideshop-module",
   "keywords": ["oxid", "modules", "eShop"],
   "homepage": "https://www.bestit-online.de",
-  "version": "3.6.8",
+  "version": "3.6.9",
   "license": [
     "GPL-3.0-only",
     "proprietary"


### PR DESCRIPTION
New tag is not displayed under https://packagist.org/packages/bestit/amazonpay4oxid and cannot be used as such